### PR TITLE
Remove healthcare reference from experience section

### DIFF
--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -61,7 +61,7 @@ export default function ExperienceSection() {
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">Experience</h2>
           <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-            A journey through aerospace, healthcare, and enterprise software development
+            A journey through aerospace and enterprise software development
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
• Remove irrelevant healthcare mention from experience section intro text
• The reference didn't reflect actual work experience shown in the portfolio

## Test plan
- [x] Verify experience section displays correctly without healthcare reference
- [x] Confirm intro text now reads "A journey through aerospace and enterprise software development"