### PR TITLE
Remove healthcare reference and improve contact buttons layout

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -93,26 +93,32 @@ export default function ContactSection() {
                 <Button
                   variant="outline"
                   className="w-full justify-start"
-                  onClick={() => window.open("https://www.linkedin.com/in/frank-palmisano", "_blank")}
+                  asChild
                 >
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  LinkedIn Profile
+                  <a href="https://www.linkedin.com/in/frank-palmisano" target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    LinkedIn Profile
+                  </a>
                 </Button>
                 <Button
                   variant="outline"
                   className="w-full justify-start"
-                  onClick={() => window.open("https://github.com/SpacePlushy", "_blank")}
+                  asChild
                 >
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  GitHub Profile
+                  <a href="https://github.com/SpacePlushy" target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    GitHub Profile
+                  </a>
                 </Button>
                 <Button
                   variant="outline"
                   className="w-full justify-start"
-                  onClick={() => window.open("https://palmisano.io", "_blank")}
+                  asChild
                 >
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  Portfolio Website
+                  <a href="https://palmisano.io" target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Portfolio Website
+                  </a>
                 </Button>
               </CardContent>
             </Card>

--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -61,7 +61,7 @@ export default function ExperienceSection() {
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">Experience</h2>
           <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-            A journey through aerospace, healthcare, and enterprise software development
+            A journey through aerospace and enterprise software development
           </p>
         </div>
 

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -36,35 +36,44 @@ export default function HeroSection() {
             </p>
           </div>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <Button
-              size="lg"
-              className="group"
-              onClick={() =>
-                (window.location.href = "mailto:frank@palmisano.io")
-              }
-            >
-              <Mail className="mr-2 h-4 w-4 group-hover:scale-110 transition-transform" />
-              Email Me
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              onClick={() => (window.location.href = "tel:+16233005532")}
-            >
-              <Phone className="mr-2 h-4 w-4" />
-              Call Me
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              onClick={() =>
-                window.open("https://www.linkedin.com/in/frank-palmisano", "_blank")
-              }
-            >
-              <ExternalLink className="mr-2 h-4 w-4" />
-              LinkedIn
-            </Button>
+          <div className="space-y-4">
+            {/* Primary contact button - full width on mobile */}
+            <div className="flex justify-center">
+              <Button
+                size="lg"
+                className="group w-full max-w-sm"
+                onClick={() =>
+                  (window.location.href = "mailto:frank@palmisano.io")
+                }
+              >
+                <Mail className="mr-2 h-4 w-4 group-hover:scale-110 transition-transform" />
+                Email Me
+              </Button>
+            </div>
+            
+            {/* Secondary contact buttons - side by side on mobile */}
+            <div className="flex gap-3 justify-center">
+              <Button
+                size="lg"
+                variant="outline"
+                className="flex-1 max-w-[140px]"
+                onClick={() => (window.location.href = "tel:+16233005532")}
+              >
+                <Phone className="mr-2 h-4 w-4" />
+                Call Me
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="flex-1 max-w-[140px]"
+                onClick={() =>
+                  window.open("https://www.linkedin.com/in/frank-palmisano", "_blank")
+                }
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                LinkedIn
+              </Button>
+            </div>
           </div>
 
           <div className="mt-12">

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -42,12 +42,12 @@ export default function HeroSection() {
               <Button
                 size="lg"
                 className="group w-full max-w-sm"
-                onClick={() =>
-                  (window.location.href = "mailto:frank@palmisano.io")
-                }
+                asChild
               >
-                <Mail className="mr-2 h-4 w-4 group-hover:scale-110 transition-transform" />
-                Email Me
+                <a href="mailto:frank@palmisano.io">
+                  <Mail className="mr-2 h-4 w-4 group-hover:scale-110 transition-transform" />
+                  Email Me
+                </a>
               </Button>
             </div>
             
@@ -57,21 +57,23 @@ export default function HeroSection() {
                 size="lg"
                 variant="outline"
                 className="flex-1 max-w-[140px]"
-                onClick={() => (window.location.href = "tel:+16233005532")}
+                asChild
               >
-                <Phone className="mr-2 h-4 w-4" />
-                Call Me
+                <a href="tel:+16233005532">
+                  <Phone className="mr-2 h-4 w-4" />
+                  Call Me
+                </a>
               </Button>
               <Button
                 size="lg"
                 variant="outline"
                 className="flex-1 max-w-[140px]"
-                onClick={() =>
-                  window.open("https://www.linkedin.com/in/frank-palmisano", "_blank")
-                }
+                asChild
               >
-                <ExternalLink className="mr-2 h-4 w-4" />
-                LinkedIn
+                <a href="https://www.linkedin.com/in/frank-palmisano" target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  LinkedIn
+                </a>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
• Remove irrelevant healthcare mention from experience section intro text
• Redesign contact buttons layout for better horizontal space utilization on mobile
• Email button now spans full width as primary contact method
• Call and LinkedIn buttons positioned side-by-side for better UX

## Changes Made
1. **Experience Section**: Removed healthcare reference from intro text as it didn't reflect actual work experience
2. **Hero Section**: Redesigned contact buttons layout:
   - Email Me button: Full width (primary contact)
   - Call Me & LinkedIn: Side-by-side below for better space usage

## Test plan
- [x] Verify experience section displays correctly without healthcare reference
- [x] Confirm contact buttons layout uses horizontal space efficiently
- [x] Test responsive behavior on mobile devices
- [x] Verify all contact methods still function properly